### PR TITLE
Support multiple results in NeptuneObserver completed_event()

### DIFF
--- a/neptunecontrib/monitoring/sacred.py
+++ b/neptunecontrib/monitoring/sacred.py
@@ -103,18 +103,19 @@ class NeptuneObserver(RunObserver):
     def completed_event(self, stop_time, result):
         if result:
             if not isinstance(result, tuple):
-                result = (result,) # transform single result to tuple so that both single & multiple results use same code
-                
+                result = (
+                    result,)  # transform single result to tuple so that both single & multiple results use same code
+
             for i, r in enumerate(result):
-                if isinstance(r, float) or isinstance(r,int):
+                if isinstance(r, float) or isinstance(r, int):
                     neptune.log_metric("result_{}".format(i), float(r))
                 elif isinstance(r, object):
                     pickle_and_send_artifact(r, "result_{}.pkl".format(i))
-                else: 
-                    warnings.warn("logging results does not support type '{}' results. Ignoring this result".format(type(r)))
+                else:
+                    warnings.warn(
+                        "logging results does not support type '{}' results. Ignoring this result".format(type(r)))
 
         neptune.stop()
-
 
     def interrupted_event(self, interrupt_time, status):
         neptune.stop()

--- a/neptunecontrib/monitoring/sacred.py
+++ b/neptunecontrib/monitoring/sacred.py
@@ -100,8 +100,18 @@ class NeptuneObserver(RunObserver):
 
     def completed_event(self, stop_time, result):
         if result:
-            neptune.log_metric('result', result)
+            if isinstance(result, tuple): # logging multiple results
+                for i, r in enumerate(result):
+                    if isinstance(r, float):
+                        neptune.log_metric(f'result_{i}', r)
+                    else: # Ignore non float results # TODO: Find a way of logging objects (log_artifact maybe??)
+                        continue
+
+            elif isinstance(result, float): # logging single result
+                neptune.log_metric('result', result)
+
         neptune.stop()
+
 
     def interrupted_event(self, interrupt_time, status):
         neptune.stop()

--- a/neptunecontrib/monitoring/sacred.py
+++ b/neptunecontrib/monitoring/sacred.py
@@ -15,8 +15,10 @@
 #
 
 import collections
+import warnings
 
 import neptune
+from neptunecontrib.monitoring.utils import pickle_and_send_artifact
 from sacred.dependencies import get_digest
 from sacred.observers import RunObserver
 
@@ -100,15 +102,16 @@ class NeptuneObserver(RunObserver):
 
     def completed_event(self, stop_time, result):
         if result:
-            if isinstance(result, tuple): # logging multiple results
-                for i, r in enumerate(result):
-                    if isinstance(r, float):
-                        neptune.log_metric(f'result_{i}', r)
-                    else: # Ignore non float results # TODO: Find a way of logging objects (log_artifact maybe??)
-                        continue
-
-            elif isinstance(result, float): # logging single result
-                neptune.log_metric('result', result)
+            if not isinstance(result, tuple):
+                result = (result,) # transform single result to tuple so that both single & multiple results use same code
+                
+            for i, r in enumerate(result):
+                if isinstance(r, float) or isinstance(r,int):
+                    neptune.log_metric("result_{}".format(i), float(r))
+                elif isinstance(r, object):
+                    pickle_and_send_artifact(r, "result_{}.pkl".format(i))
+                else: 
+                    warnings.warn("logging results does not support type '{}' results. Ignoring this result".format(type(r)))
 
         neptune.stop()
 


### PR DESCRIPTION
When using sacred the `result` variable can be either a float (which `NeptuneObserver` code currently supports) or multiple results (a tuple, which causes a crash do to `neptune.log_metrics()` not supporting tuples).

This is a quick fix I made ... but it would be nice that if one of the elements of the tuple is object (e.g. If parts of my results is a buffer / dataset) I could also store it